### PR TITLE
Fix: templates not compiled on Windows (empty build output)

### DIFF
--- a/packages/cli/src/webpack/webpack.config.templates.js
+++ b/packages/cli/src/webpack/webpack.config.templates.js
@@ -62,7 +62,7 @@ module.exports = ({
       fallback: { os: false, stream: false },
     },
     entry: () =>
-      glob.sync(`${templatesDir}/**/${templateId || '*'}.template.{ts,tsx,js,jsx}`).reduce(
+      glob.sync(`${templatesDir.split(path.sep).join('/')}/**/${templateId || '*'}.template.{ts,tsx,js,jsx}`).reduce(
         (obj, el) => ({
           ...obj,
           [path


### PR DESCRIPTION
getTemplatesDirectory uses path.resolve() which returns backslash paths on Windows (e.g. C:\project\src). These are passed directly to glob.sync, which requires forward slashes and silently returns zero matches. Webpack then runs with an empty entry and produces no output — no error, just nothing compiled.

The fix converts path.sep separators to / before building the glob pattern, which is a no-op on Mac/Linux.